### PR TITLE
Rename OXT to O for dssp

### DIFF
--- a/martinize/secstruc.py
+++ b/martinize/secstruc.py
@@ -182,7 +182,7 @@ def call_dssp(chain, atomlist, executable='dsspcmbi'):
         sys.exit(1)
 
     for atom in atomlist:
-        if atom[0][:2] == 'O1': atom = ('O',)+atom[1:]
+        if atom[0][:2] == 'O1' or atom[0][:3] == 'OXT': atom = ('O',)+atom[1:]
         if atom[0][0] != 'H' and atom[0][:2] != 'O2': p.stdin.write(IO.pdbOut(atom))
     p.stdin.write('TER\n')
     data = p.communicate()


### PR DESCRIPTION
DSSP can sometime trip on the C terminal residue of a protein, ignoring
it because the oxygen is named OXT. The error is not systematic, but
when it happens it causes the last residue not to appear on the output
PDB file. The residue still appear in the ITP file causing a mismatch.

This commit renames the OXT atom to O in the structure that is passed to
DSSP.